### PR TITLE
[WIP] Support Raspberry pi 4

### DIFF
--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -114,7 +114,7 @@ detect_steamlink
 """)
 
     with open('/tmp/steamlink-watchdog.sh', 'w') as outfile:
-        outfile.write("""#!/bin/bash -e
+        outfile.write("""#!/bin/bash
 # watchdog part
 watchdog_osmc () {
 sudo systemctl stop mediacenter

--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -57,7 +57,17 @@ wget https://raw.githubusercontent.com/swetoast/steamlink-launcher/dev/libreelec
    
    rm /storage/steamlink/steamlink.tar.gz
    rm -r /storage/rasbian/
+
+   # Note:
+   # Since we are running it for Raspberry pi 4, we should not check the CPU informations
+   touch /storage/steamlink/.ignore_cpuinfo
    
+   # Also we'd better use the right place to setup the udev rules
+   sed -i 's@UDEV_RULES_DIR=/lib/udev/rules.d@UDEV_RULES_DIR=/storage/.config/udev.rules.d@' /storage/steamlink/steamlink.sh
+   
+   # Also we better remove allthe 'sudo' references (LibreElec doesn't like that)
+   sed -i 's@sudo @@g' /storage/steamlink/steamlink.sh
+
    # Note:
    # Last command so we are sure the installation script has been completed (bash -e will interrupt this script as soon as it encounters an error)
    touch /storage/steamlink/steamlink

--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -23,7 +23,7 @@ def main():
 def create_files():
     """Creates bash files to be used for this plugin."""
     with open('/tmp/steamlink-launcher.sh', 'w') as outfile:
-        outfile.write("""#!/bin/sh
+        outfile.write("""#!/bin/sh -e
 # installation part
 install_on_libre () {
 kodi-send --action="Notification(Installing Steamlink, Please wait while installing Steamlink and packages.. this might take awhile,1500)"
@@ -38,7 +38,7 @@ wget https://downloads.raspberrypi.org/raspbian_full_latest -O /storage/raspbian
 wget "$(wget -q -O - http://media.steampowered.com/steamlink/rpi/public_build.txt)" -O /storage/steamlink/steamlink.tar.gz
 wget https://raw.githubusercontent.com/swetoast/steamlink-launcher/dev/libreelec_additonal/60-steam-input.rules -O /storage/.config/system.d/storage-steamlink-udev-rules.d.mount
 
-   tar -zxf /storage/steamlink/steamlink.tar.gz
+   tar -zxf /storage/steamlink/steamlink.tar.gz --strip-components 1
    unzip /storage/raspbian/raspbian-stretch-full.zip
       
    mount -o loop,ro,offset=50331648 -t ext4 /storage/raspbian/raspbian-stretch-full.zip
@@ -48,13 +48,19 @@ wget https://raw.githubusercontent.com/swetoast/steamlink-launcher/dev/libreelec
    umount /storage/raspbian/lib
    
    mv /storage/raspbian/lib/* /storage/steamlink/lib
-   mv /storage/steamlink/udev/rules.d/55-steamlink.rules /storage/.config/udev.rules.d/55-steamlink.rules
+   mv /storage/steamlink/udev/rules.d/56-steamlink.rules /storage/.config/udev.rules.d/56-steamlink.rules
 
+   systemctl daemon-reload
    systemctl enable storage-steamlink-udev-rules.d.mount
+   systemctl start storage-steamlink-udev-rules.d.mount
    udevadm trigger
    
    rm /storage/steamlink/steamlink.tar.gz
    rm -r /storage/rasbian/
+   
+   # Note:
+   # Last command so we are sure the installation script has been completed (bash -e will interrupt this script as soon as it encounters an error)
+   touch /storage/steamlink/steamlink
 
 start_steamlink
 }
@@ -98,7 +104,7 @@ detect_steamlink
 """)
 
     with open('/tmp/steamlink-watchdog.sh', 'w') as outfile:
-        outfile.write("""#!/bin/bash
+        outfile.write("""#!/bin/bash -e
 # watchdog part
 watchdog_osmc () {
 sudo systemctl stop mediacenter

--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -43,7 +43,7 @@ wget https://raw.githubusercontent.com/swetoast/steamlink-launcher/dev/libreelec
       
    mount -o loop,ro,offset=50331648 -t ext4 /storage/raspbian/raspbian-stretch-full.zip
    cd /storage/raspbian/lib
-   for i in libpng16.so.16 libicui18n.so.57 libicuuc.so.57 libicudata.so.57 libX11-xcb.so.1 libX11.so.6 libXext.so.6 libxcb.so.1 libxkbcommon-x11.so.0 libXau.so.6 libXdmcp.so.6 libxcb-xkb.so.1 libbsd.so.0; do cp "$(find -name $i)" .. ; done
+   for i in libjpeg.so.62 libpng16.so.16 libicui18n.so.57 libicuuc.so.57 libicudata.so.57 libX11-xcb.so.1 libX11.so.6 libXext.so.6 libxcb.so.1 libxkbcommon-x11.so.0 libXau.so.6 libXdmcp.so.6 libxcb-xkb.so.1 libbsd.so.0; do cp "$(find -name $i)" .. ; done
    cd ..
    umount /storage/raspbian/lib
    

--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -134,7 +134,7 @@ if [ "$HYPERIONFIX" = 1 ]; then
    if [ ! "$(pgrep hyperion)" ]; then systemctl start hyperion; fi
 fi
 systemctl stop kodi
-/storage/steamlink/steamlink.sh &> /storage/steamlink/steamlink.log >/dev/null 2>&1 &
+nohup /storage/steamlink/steamlink.sh > /storage/steamlink/steamlink.log 2>&1 &
 systemctl start kodi
 }
 

--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -67,7 +67,11 @@ wget https://raw.githubusercontent.com/swetoast/steamlink-launcher/dev/libreelec
    
    # Also we better remove allthe 'sudo' references (LibreElec doesn't like that)
    sed -i 's@sudo @@g' /storage/steamlink/steamlink.sh
-
+   
+   # This will allow Steamlink to start, but there is no way to make it stream any games
+   # It is a step further but not yet working sadly
+   sed -i 's@QPLATFORM="eglfs"@QPLATFORM="linuxfb"@' /storage/steamlink/steamlink.sh
+   
    # Note:
    # Last command so we are sure the installation script has been completed (bash -e will interrupt this script as soon as it encounters an error)
    touch /storage/steamlink/steamlink


### PR DESCRIPTION
For LibreElec on Raspberry pi 4 it missees this dependency `libjpeg.so.62`, but also some other fixes are needed but on the steam installation script, which is quite annoying since we cannot update it (it doesn't use any global variable.

I also reworked a bit the steam installation bash script, but it doesn't work quite atm.
```sh
#!/bin/bash
#
# Script to launch the Steam Link app on Raspberry Pi

TOP=$(cd "$(dirname "$0")" && pwd)

function show_message()
{
  style=$1
  shift
  if ! zenity "$style" --no-wrap --text="$*" 2>/dev/null; then
    case "$style" in
    --error)
      title=$"Error"
      ;;
    --warning)
      title=$"Warning"
      ;;
    *)
      title=$"Note"
      ;;
    esac

    # Save the prompt in a temporary file because it can have newlines in it
    tmpfile="$(mktemp || echo "/tmp/steam_message.txt")"
    echo -e "$*" >"$tmpfile"
    if [ "$DISPLAY" = "" ]; then
      cat $tmpfile; echo -n 'Press enter to continue: '; read input
    else
      xterm -T "$title" -e "cat $tmpfile; echo -n 'Press enter to continue: '; read input"
    fi
    rm -f "$tmpfile"
  fi
}

# Check to make sure the hardware is capable of streaming at 1080p60
# Model code information from:
# https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
if [ ! -f "$TOP/.ignore_cpuinfo" ]; then
  revision=$(cat /proc/cpuinfo | fgrep "Revision" | sed 's/.*: //')

  # NOTE:
  # This is not needed since we are running the script on Raspberry pi 4

# revision=$((16#$revision))
# processor=$(($(($revision >> 12)) & 0xf)) # 0: BCM2835, 1: BCM2836, 2: BCM2837, 3: BCM2711
# if [ $processor -lt 2 ]; then
#   show_message --error $"You need to run on a Raspberry Pi 3 or newer - aborting."
#   exit 1
# fi
fi

# Check to make sure the experimental OpenGL driver isn't enabled
if [ ! -f "$TOP/.ignore_kms" ]; then
  if egrep '^dtoverlay=vc4-kms-v3d' /boot/config.txt >/dev/null 2>&1; then
    show_message --error $"You have dtoverlay=vc4-kms-v3d in /boot/config.txt, which will cause a black screen when starting streaming - aborting.\nTry commenting out that line and rebooting."
    exit 1
  fi
fi

# Install any additional dependencies, as needed
if [ -z "${STEAMSCRIPT:-}" ]; then
  STEAMSCRIPT=/usr/bin/steamlink
fi
STEAMDEPS="$(dirname $STEAMSCRIPT)/steamlinkdeps"
if [ -f "$STEAMDEPS" -a -f "$TOP/steamlinkdeps.txt" ]; then
  "$STEAMDEPS" "$TOP/steamlinkdeps.txt"
fi

# Check to make sure the Steam Controller rules are installed
# NOTE:
# LibreElect doesn't use the same directory so we use the udev rules from the storage directory
UDEV_RULES_DIR=/storage/.config/udev.rules.d
UDEV_RULES_FILE=56-steamlink.rules

if [ ! -f "$UDEV_RULES_DIR/$UDEV_RULES_FILE" ];
then
  title="Updating udev rules"

  script="$(mktemp || echo "/tmp/steamlink_copy_udev_rules.sh")"
  cat >$script <<__EOF__
echo "Copying Steam Link udev rules into place..."
rm -f $UDEV_RULES_DIR/*-steamlink.rules
cp -v $TOP/udev/modules-load.d/* /etc/modules-load.d/ && modprobe uinput && sleep 3

# NOTE:
# usermod is not required since LibreElect runs as root (WTF right?!)
cp -v $TOP/udev/rules.d/$UDEV_RULES_FILE $UDEV_RULES_DIR/$UDEV_RULES_FILE && udevadm trigger
echo -n "Press return to continue: "
read line
__EOF__
  if [ "$DISPLAY" = "" ]; then
    /bin/sh $script
  elif which lxterminal >/dev/null; then
    lxterminal -t "$title" -e /bin/sh $script

    # Wait for the script to complete
    sleep 3
    while ps aux | grep -v grep | grep $script >/dev/null; do
      sleep 1
    done
  elif which xterm >/dev/null; then
    xterm -bg "#383635" -fg "#d1cfcd" -T "$title" -e /bin/sh $script
  else
    /bin/sh $script
  fi
  rm -f $script
fi

# Set up the temporary directory
export TMPDIR="$TOP/.tmp"
rm -rf "$TMPDIR"
mkdir -p "$TMPDIR"

# Restore the display when we're done
cleanup()
{
  if [ "$CEC_PID" != "" ]; then
    kill $CEC_PID 2>/dev/null
  fi
  screenblank -k
}
trap cleanup 2 3 15

# Run the shell application and launch streaming
QT_VERSION=5.14.1
export PATH="$TOP/bin:$PATH"
export QTDIR="$TOP/Qt-$QT_VERSION"
export QT_PLUGIN_PATH="$QTDIR/plugins"
export LD_LIBRARY_PATH="$TOP/lib:$QTDIR/lib:$LD_LIBRARY_PATH"
export SDL_GAMECONTROLLERCONFIG_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/Valve Corporation/SteamLink/controller_map.txt"

if [ "$DISPLAY" = "" ]; then
  QPLATFORM="eglfs"
  export QT_QPA_EGLFS_FORCE888=1
else
  QPLATFORM="xcb"
fi

if [ -f "$TOP/.ignore_cec" ]; then
  CEC_PID=""
else
  cec-client </dev/null | steamlink-cec &
  CEC_PID="$(jobs -p) $!"
fi

restart=false
while true; do
  shell -platform "$QPLATFORM" "$@"

  # See if the shell wanted to launch anything
  cmdline_file="$TMPDIR/launch_cmdline.txt"
  if [ -f "$cmdline_file" ]; then
    cmd=`cat "$cmdline_file"`
    if [ "$cmd" = "\"steamlink\"" ]; then
      restart=true
      rm -f "$cmdline_file"
      break
    else
      eval $cmd
      rm -f "$cmdline_file"

      # We're all done if it was a single session launch
      if echo "$cmd" | fgrep "://" >/dev/null; then
        break
      fi
    fi
  else
    # We're all done...
    break
  fi
done
cleanup

if [ "$restart" = "true" ]; then
  exec steamlink "$@"
fi
exit 0
```