### PR TITLE
Fix typo causing Error reading Attributes

### DIFF
--- a/plugin.program.steamlink/addon.xml
+++ b/plugin.program.steamlink/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.program.steamlink" name="Steamlink Launcher" version="0.0.7a" provider-name="Toast">
   <requires>
-    <import addon="xbmc.python" version="3.0.0""/>
+    <import addon="xbmc.python" version="3.0.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="addon.py">
     <provides>executable</provides>


### PR DESCRIPTION
Installing from zip results in
ERROR <general>: CAddonInfoBuilder::Generate: Unable to load addon.xml Line 4 Error reading Attributes.
Removing the extra double quote.