### PR TITLE
Install steamlink if it NOT found by the which-command

### DIFF
--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -52,7 +52,7 @@ if [ ! $(dpkg --list | grep libgl1-mesa-dri) ]; then
     kodi-send --action="Notification(Downloading and installing Steamlink depenancies (libgl1-mesa-dri)... ,3000)" 
     sudo apt install libgl1-mesa-dri -y 
 fi
-if [ ! "$(which steamlink)" = "" ]; then
+if [ "$(which steamlink)" = "" ]; then
     kodi-send --action="Notification(Downloading and installing Steamlink Application... ,3000)" 
     curl -o /tmp/steamlink.deb -#Of http://media.steampowered.com/steamlink/rpi/latest/steamlink.deb
     sudo dpkg -i /tmp/steamlink.deb


### PR DESCRIPTION
Fixes an issue where steamlink would only be downloaded if it is already installed. The problem seems to have been introduced in the watchdog rewrite a few months back (903885c085796f9002f3dce31e6d2dbedce7fa83).