### PR TITLE
fix: too many arguments

### DIFF
--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -32,23 +32,23 @@ sudo su -c "nohup sudo openvt -c 7 -s -f -l /tmp/steamlink-watchdog.sh >/dev/nul
     with open('/tmp/steamlink-watchdog.sh', 'w') as outfile:
         outfile.write("""#!/bin/bash
         sudo apt update # write a better update check
-if [ ! $(dpkg --list | grep gnupg) ]; then 
+if [ ! dpkg --list | grep -q gnupg ]; then 
    kodi-send --action="Notification(Downloading and installing Steamlink depenancies (gnupg)... ,3000)"
    sudo apt install gnupg -y
 fi
-if [ ! $(dpkg --list | grep curl) ]; then 
+if [ ! dpkg --list | grep -q curl ]; then 
     kodi-send --action="Notification(Downloading and installing Steamlink depenancies (curl)... ,3000)" 
     sudo apt install curl -y 
 fi
-if [ ! $(dpkg --list | grep libgles2) ]; then 
+if [ ! dpkg --list | grep -q libgles2 ]; then 
     kodi-send --action="Notification(Downloading and installing Steamlink depenancies (libgles2)... ,3000)" 
     sudo apt install libgles2 -y 
 fi
-if [ ! $(dpkg --list | grep libegl1) ]; then 
+if [ ! dpkg --list | grep -q libegl1 ]; then 
     kodi-send --action="Notification(Downloading and installing Steamlink depenancies (libegl1)... ,3000)" 
     sudo apt install libegl1 -y 
 fi
-if [ ! $(dpkg --list | grep libgl1-mesa-dri) ]; then 
+if [ ! dpkg --list | grep -q libgl1-mesa-dri ]; then 
     kodi-send --action="Notification(Downloading and installing Steamlink depenancies (libgl1-mesa-dri)... ,3000)" 
     sudo apt install libgl1-mesa-dri -y 
 fi


### PR DESCRIPTION
When I start Steamlink Launcher, I get the errors:

```
/tmp/steamlink-watchdog.sh: line 3: [: too many arguments
/tmp/steamlink-watchdog.sh: line 7: [: too many arguments
/tmp/steamlink-watchdog.sh: line 11: [: too many arguments
/tmp/steamlink-watchdog.sh: line 15: [: too many arguments
/tmp/steamlink-watchdog.sh: line 19: [: too many arguments
```

### Environment

- Steamlink Launcher: 0.0.12
- bash: version 5.1.4(1)-release (arm-unknown-linux-gnueabihf)
- Debian: Bullseye 11.3 ([next OSMC](https://discourse.osmc.tv/t/testing-debian-11-bullseye/93054))
- `dpkg --list | grep gnupg`

```
ii  gnupg                                2.2.27-2+deb11u1               all          GNU privacy guard - a free PGP replacement
ii  gnupg-l10n                           2.2.27-2+deb11u1               all          GNU privacy guard - localization files
ii  gnupg-utils                          2.2.27-2+deb11u1               armhf        GNU privacy guard - utility programs
```

### Solution

[ShellCheck](https://www.shellcheck.net/) reports [SC2046](https://www.shellcheck.net/wiki/SC2046) and [SC2143](https://www.shellcheck.net/wiki/SC2143).

```
Line 3:
if [ ! $(dpkg --list | grep gnupg) ]; then
       ^-- SC2046 (warning): Quote this to prevent word splitting.
       ^-- SC2143 (style): Use grep -q instead of comparing output with [ -n .. ].
 
Line 7:
if [ ! $(dpkg --list | grep curl) ]; then
       ^-- SC2046 (warning): Quote this to prevent word splitting.
       ^-- SC2143 (style): Use grep -q instead of comparing output with [ -n .. ].
 
Line 11:
if [ ! $(dpkg --list | grep libgles2) ]; then
       ^-- SC2046 (warning): Quote this to prevent word splitting.
       ^-- SC2143 (style): Use grep -q instead of comparing output with [ -n .. ].
 
Line 15:
if [ ! $(dpkg --list | grep libegl1) ]; then
       ^-- SC2046 (warning): Quote this to prevent word splitting.
       ^-- SC2143 (style): Use grep -q instead of comparing output with [ -n .. ].
 
Line 19:
if [ ! $(dpkg --list | grep libgl1-mesa-dri) ]; then
       ^-- SC2046 (warning): Quote this to prevent word splitting.
       ^-- SC2143 (style): Use grep -q instead of comparing output with [ -n .. ].
```