### PR TITLE
Improvements to steamlink-watchdog.sh

### DIFF
--- a/plugin.program.steamlink/addon.py
+++ b/plugin.program.steamlink/addon.py
@@ -62,10 +62,19 @@ if [ -f "/home/osmc/.wakeup" ]
    then /usr/bin/wakeonlan "$(cat "/home/osmc/.wakeup")"
    else sudo apt install wakeonlan -y; /usr/bin/wakeonlan "$(cat "/home/osmc/.wakeup")" 
 fi
+if [ -x "/home/osmc/steamlink/startup.sh" ]
+   then sudo -u osmc /home/osmc/steamlink/startup.sh
+fi
+
 systemctl stop mediacenter
 if [ "$(systemctl is-active hyperion.service)" = "active" ]; then systemctl restart hyperion; fi
 sudo -u osmc steamlink
 openvt -c 7 -s -f clear
+
+if [ -x "/home/osmc/steamlink/shutdown.sh" ]
+   then sudo -u osmc /home/osmc/steamlink/shutdown.sh
+fi
+
 systemctl start mediacenter
 """)
         outfile.close()


### PR DESCRIPTION
Two improvements to this script:

- Tweaked how dependencies are checked for to ensure that apt commands are only run if needed (previous version always ran `apt get update` and tried to install wakeonlan even if the .wakeup file didn't exist)
- Added the option to have startup and shutdown scripts (useful if you need something more complex than wakeonlan, e.g. I have a script that logs into my PC and starts up Steam).